### PR TITLE
Add disk usage tests using Bats

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ Make scripts executable and run them. For example:
 ```bash
 chmod +x scripts/auto_backup.sh
 ./scripts/auto_backup.sh
+```
+
+## Running tests
+
+This project uses [Bats](https://bats-core.readthedocs.io/) for testing. After installing Bats, run the suite with:
+
+```bash
+bats tests
+```

--- a/tests/disk_usage.bats
+++ b/tests/disk_usage.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMPDIR="$(mktemp -d)"
+  PATH="$TMPDIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+@test "disk usage below threshold reports OK" {
+  cat <<'EODF' > "$TMPDIR/df"
+#!/bin/bash
+echo "Filesystem 1K-blocks Used Available Use% Mounted on"
+echo "mock 100 50 50 50% /"
+EODF
+  chmod +x "$TMPDIR/df"
+
+  run "$BATS_TEST_DIRNAME/../scripts/disk_usage.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Disk usage is OK"* ]]
+}
+
+@test "disk usage above threshold warns" {
+  cat <<'EODF' > "$TMPDIR/df"
+#!/bin/bash
+echo "Filesystem 1K-blocks Used Available Use% Mounted on"
+echo "mock 100 90 10 90% /"
+EODF
+  chmod +x "$TMPDIR/df"
+
+  run "$BATS_TEST_DIRNAME/../scripts/disk_usage.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Disk usage above threshold"* ]]
+}


### PR DESCRIPTION
## Summary
- add Bats tests for disk_usage.sh with mock `df`
- document running tests in README

## Testing
- `bats tests/disk_usage.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd63a37388325b72483d725a20969